### PR TITLE
feat: spotify icons

### DIFF
--- a/svg/spotify-filled.svg
+++ b/svg/spotify-filled.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24">
+  <mask id="lineMdSpotifyFilled0">
+    <g fill="none" fill-opacity="0" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+      <path fill="#fff" stroke-dasharray="64" stroke-dashoffset="64" d="M3 12c0 -4.97 4.03 -9 9 -9c4.97 0 9 4.03 9 9c0 4.97 -4.03 9 -9 9c-4.97 0 -9 -4.03 -9 -9Z">
+        <animate fill="freeze" attributeName="fill-opacity" begin="0.6s" dur="0.5s" values="0;1" />
+        <animate fill="freeze" attributeName="stroke-dashoffset" dur="0.6s" values="64;0" />
+      </path>
+      <path stroke="#000" stroke-width="1.85" stroke-dasharray="14" stroke-dashoffset="14" d="M 6.04,8.87 C 11.55,7.36 16.92,9.13 18.42,10.15">
+        <animate fill="freeze" attributeName="stroke-dashoffset" begin="1.1s" dur="0.2s" values="14;0" />
+      </path>
+      <path stroke="#000" stroke-width="1.53" stroke-dasharray="12" stroke-dashoffset="12" d="m 6.58,12.07 c 4.82,-1.41 9.15,0.30 10.57,1.24">
+        <animate fill="freeze" attributeName="stroke-dashoffset" begin="1.3s" dur="0.2s" values="12;0" />
+      </path>
+      <path stroke="#000" stroke-width="1.22" stroke-dasharray="12" stroke-dashoffset="12" d="m 6.80,15.10 c 4.60,-1.04 7.43,-0.08 9.27,1.04">
+        <animate fill="freeze" attributeName="stroke-dashoffset" begin="1.5s" dur="0.2s" values="12;0" />
+      </path>
+    </g>
+  </mask>
+  <rect width="24" height="24" fill="currentColor" mask="url(#lineMdSpotifyFilled0)" />
+</svg>

--- a/svg/spotify.svg
+++ b/svg/spotify.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24">
+  <g fill="none" fill-opacity="0" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round">
+    <path stroke-width="2" stroke-dasharray="64" stroke-dashoffset="64" d="M3 12c0 -4.97 4.03 -9 9 -9c4.97 0 9 4.03 9 9c0 4.97 -4.03 9 -9 9c-4.97 0 -9 -4.03 -9 -9Z">
+      <animate fill="freeze" attributeName="stroke-dashoffset" begin="0s" dur="0.8s" values="64;0" />
+    </path>
+    <path stroke-width="1.45" stroke-dasharray="14" stroke-dashoffset="14" d="M 6.64,9.11 C 11.60,7.76 16.43,9.34 17.78,10.26">
+      <animate fill="freeze" attributeName="stroke-dashoffset" begin="0.8s" dur="0.2s" values="14;0" />
+    </path>
+    <path stroke-width="1.13" stroke-dasharray="12" stroke-dashoffset="12" d="m 7.13,12.06 c 4.33,-1.27 8.24,0.27 9.51,1.11">
+      <animate fill="freeze" attributeName="stroke-dashoffset" begin="1s" dur="0.2s" values="12;0" />
+    </path>
+    <path stroke-width="0.82" stroke-dasharray="12" stroke-dashoffset="12" d="m 7.32,14.86 c 4.14,-0.93 6.68,-0.07 8.35,0.94">
+      <animate fill="freeze" attributeName="stroke-dashoffset" begin="1.2s" dur="0.2s" values="12;0" />
+    </path>
+  </g>
+</svg>


### PR DESCRIPTION
Fixes #25

Filled version is based on `mdi:spotify` icon.

Line version was designed based on filled version, with slightly smaller details inside.